### PR TITLE
add missing dependency in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gulp-markdown-table-to-json 
+
 [![NPM version][npm-image]][npm-url]
+
 > A github-style-markdown table parse plugin for gulp 3
 
 ## Usage
@@ -13,27 +15,33 @@ npm install --save-dev gulp-markdown-table-to-json
 Then, add it to your `gulpfile.js`:
 
 ### Write Some Tables in Markdown File
+
 ###### boys
+
 name | age| grade 
 -----|----|-----
 John|11|3
 Bob|13|4
 
 ###### girls
+
 name | age| grade | 
 -----|----|-----
 Petra|15|8
 Olivia|14|7
 
 #### source code
+
 ```markdown
 ###### boys
+
 name | age| grade 
 -----|----|-----
 John|11|3
 Bob|13|4
 
 ###### girls
+
 name | age| grade | 
 -----|----|-----
 Petra|15|8
@@ -41,8 +49,10 @@ Olivia|14|7
 ```
 
 ### Get Json
+
 ```javascript
-var md2json = require('gulp-markdown-table-to-json');
+var gulp = require('gulp'),
+    md2json = require('gulp-markdown-table-to-json');
 
 gulp.task('md2json', function(){
   gulp.src('README.md')
@@ -52,10 +62,13 @@ gulp.task('md2json', function(){
 ```
 
 Then you will get a json file named README.json with the following content:
+
 ```json
 {"boys":[{"name":"John","age":"11","grade":"3"},{"name":"Bob","age":"13","grade":"4"}],"girls":[{"name":"Petra","age":"15","grade":"8"},{"name":"Olivia","age":"14","grade":"7"}]}
 ```
+
 If you want to beautify it, you can use the gulp plugin "gulp-beautify". And you will get the following content:
+
 ```json
 {
     "boys": [{
@@ -78,19 +91,16 @@ If you want to beautify it, you can use the gulp plugin "gulp-beautify". And you
     }]
 }
 ```
+
 ## API
 
 ### md2json(anchor)
 
 #### anchor
+
 Type: `String`
 
 The string to search for table title. Default is "######".
-
-
-
-
-
 
 [npm-url]: https://npmjs.org/package/gulp-markdown-table-to-json
 [npm-image]: http://img.shields.io/npm/v/gulp-markdown-table-to-json.svg

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ Olivia|14|7
 ### Get Json
 
 ```javascript
-var gulp = require('gulp'),
-    md2json = require('gulp-markdown-table-to-json');
+var md2json = require('gulp-markdown-table-to-json');
 
 gulp.task('md2json', function(){
   gulp.src('README.md')


### PR DESCRIPTION
- add missing dependency in example
- fix markdown syntax about spacing